### PR TITLE
Changes to get PY2020/Jetson-Can branch to compile

### DIFF
--- a/CANPacket.h
+++ b/CANPacket.h
@@ -34,6 +34,8 @@ uint8_t GetSenderDeviceSerialNumber(CANPacket *packet);
 uint8_t GetSenderDeviceGroupCode(CANPacket *packet);
 
 int PacketIsInGroup(CANPacket *packet, uint8_t expectedType);
+int SenderPacketIsInGroup(CANPacket *packet, uint8_t expectedType);
+int SenderPacketIsOfDevice(CANPacket *packet, uint8_t expectedType);
 int TargetsDevice(CANPacket *packet, uint8_t targetDeviceGroup, uint8_t targetDeviceSerialNumber);
 
 int GetPacketID(CANPacket *packet);

--- a/Port.c
+++ b/Port.c
@@ -1,9 +1,9 @@
 /*
  * Documentation: https://huskyroboticsteam.slite.com/app/channels/iU0BryG7M9/collections/aXvWTcIR6c/notes/4otlSFsSp2
  */
-#if CHIP_TYPE == CHIP_TYPE_TEMPLATE//Replace this with the chip you are porting
+#define CHIP_TYPE 0
 
-#include "port.h"
+#include "Port.h"
 
 void InitCAN(int deviceGroup, int deviceAddress)
 {
@@ -34,4 +34,3 @@ uint8_t getChipType()
     return CHIP_TYPE; 
     //Should be same for all ports, just not sure where to put it.
 }
-#endif //CHIP_TYPE == CHIP_TYPE_TEMPLATE

--- a/PortTemplate.c
+++ b/PortTemplate.c
@@ -1,7 +1,8 @@
 /*
  * Documentation: https://huskyroboticsteam.slite.com/app/channels/iU0BryG7M9/collections/aXvWTcIR6c/notes/4otlSFsSp2
  */
-#define CHIP_TYPE 0
+#define CHIP_TYPE CHIP_TYPE_TEMPLATE
+#if CHIP_TYPE == CHIP_TYPE_TEMPLATE//Replace this with the chip you are porting
 
 #include "Port.h"
 
@@ -34,3 +35,4 @@ uint8_t getChipType()
     return CHIP_TYPE; 
     //Should be same for all ports, just not sure where to put it.
 }
+#endif //CHIP_TYPE == CHIP_TYPE_TEMPLATE

--- a/PortTemplate.c
+++ b/PortTemplate.c
@@ -1,7 +1,6 @@
 /*
  * Documentation: https://huskyroboticsteam.slite.com/app/channels/iU0BryG7M9/collections/aXvWTcIR6c/notes/4otlSFsSp2
  */
-#define CHIP_TYPE CHIP_TYPE_TEMPLATE
 #if CHIP_TYPE == CHIP_TYPE_TEMPLATE//Replace this with the chip you are porting
 
 #include "Port.h"


### PR DESCRIPTION
Adds a couple of methods (which were already implemented) to the
corresponding header file. Also moves PortTemplate.c to Port.c and makes
it compile-able.

I'm guessing there's something wrong with these changes to
PortTemplate.c, but I don't understand how we're supposed to implement
Port.c. Possibilities included:

* Put it in this directory (in the git submodule)? But then it's
impossible to track changes to Port.c; the submodule commit will always
be dirty.

* Make a new branch of this repo and checkout that branch in the
container repo? But that invites merge conflicts, and it doesn't seem to
be what people have done (I don't see many branches on this repo).

* Put all of the different "subclasses" of PortTemplate.c in this repo
with unique names, and choose the right one to compile using CMakeLists
in the container repo? That would work, but then I don't see why we need
a PortTemplate.c at all. (People wanting to implement a new Port could
just copy one of the existing ones.)

I'm happy to make changes; all I really want is for the Jetson-Can
branch on PY2020 to compile.