### PR TITLE
Fix several bugs

### DIFF
--- a/CANCommon.c
+++ b/CANCommon.c
@@ -229,7 +229,7 @@ void AssembleTelemetryReportPacket(CANPacket *packetToAssemble,
 
 int32_t DecodeTelemetryDataSigned(CANPacket *packet)
 {
-    return DecodeBytesToIntMSBFirst(packet->data, 3, 6);
+    return DecodeBytesToIntMSBFirst(packet->data, 3, 7);
 }
 
 uint32_t DecodeTelemetryDataUnsigned(CANPacket *packet)

--- a/CANPacket.c
+++ b/CANPacket.c
@@ -63,7 +63,7 @@ CANPacket ConstructCANPacket(uint16_t id, uint8_t dlc, uint8_t* data)
 //                      Index of next byte in `data` that can be written
 int WriteSenderSerialAndPacketID(uint8_t *data, uint8_t packetID)
 {
-    data[0] = ((getLocalDeviceGroup() & 0x0C) << 6) | packetID;
+    data[0] = ((getLocalDeviceGroup() & 0x0C) << 4) | packetID;
     data[1] = ((getLocalDeviceGroup() & 0x03) << 6) | getLocalDeviceSerial();
     return 2;
 }
@@ -202,7 +202,7 @@ void PackIntIntoDataMSBFirst(uint8_t *data, int32_t dataToPack, int startIndex)
     data[startIndex]     = (dataToPack & 0xFF000000) >> 24;
     data[startIndex + 1] = (dataToPack & 0x00FF0000) >> 16;
     data[startIndex + 2] = (dataToPack & 0x0000FF00) >> 8;
-    data[startIndex + 4] = (dataToPack & 0x000000FF);
+    data[startIndex + 3] = (dataToPack & 0x000000FF);
 }
 
 int32_t DecodeBytesToIntMSBFirst(uint8_t *data, int startIndex, int endIndex)
@@ -218,6 +218,7 @@ int32_t DecodeBytesToIntMSBFirst(uint8_t *data, int startIndex, int endIndex)
 
     for (int i = 0; i < length; i++) 
     {
-        decodedData |= data[startIndex + i] << (8 * i);
+        decodedData |= data[startIndex + i] << (8 * (length-1-i));
     }
+    return decodedData;
 }

--- a/PortTemplate.c
+++ b/PortTemplate.c
@@ -23,10 +23,12 @@ uint8_t getLocalDeviceSerial()
 {
     //Reading DIP switches? Hard coded?
     //This might be board specific, rather than chip specific.
+    return DEVICE_SERIAL_MOTOR_CHASSIS_FR; // example value (also used for testing)
 }
 uint8_t getLocalDeviceGroup()
 {
     //Definitely board specific.
+    return DEVICE_GROUP_MOTOR_CONTROL; // example value (also used for testing)
 }
 
 uint8_t getChipType()


### PR DESCRIPTION
- We were decoding data LSB-first, not MSB-first
- We were bit-shifting the first two bits of the sender device group too far
- We did not use the correct end index for decoding telemetry data
- There was a typo when encoding data (4 instead of 3)
- Also added some example return values in PortTemplate.c to facilitate testing