### PR TITLE
Make the return type of GetPIDTargetFromPacket signed

### DIFF
--- a/CANMotorUnit.c
+++ b/CANMotorUnit.c
@@ -62,7 +62,7 @@ void AssemblePIDTargetSetPacket(CANPacket *packetToAssemble,
     PackIntIntoDataMSBFirst(packetToAssemble->data, target, nextByte);
 }
 
-uint32_t GetPIDTargetFromPacket(CANPacket *packet)
+int32_t GetPIDTargetFromPacket(CANPacket *packet)
 {
     return DecodeBytesToIntMSBFirst(packet->data, DLC_MOTOR_UNIT_PID_POS_TGT_SET - 4, DLC_MOTOR_UNIT_PID_POS_TGT_SET);
 }

--- a/CANMotorUnit.h
+++ b/CANMotorUnit.h
@@ -31,7 +31,7 @@ void AssemblePIDTargetSetPacket(CANPacket *packetToAssemble,
     uint8_t targetDeviceGroup,
     uint8_t targetDeviceSerial,
     int32_t target);
-uint32_t GetPIDTargetFromPacket(CANPacket *packet);
+int32_t GetPIDTargetFromPacket(CANPacket *packet);
 
 //P coeffiecent set
 void AssemblePSetPacket(CANPacket *packetToAssemble,

--- a/PortFiles/PortTemplate.c
+++ b/PortFiles/PortTemplate.c
@@ -3,7 +3,7 @@
  */
 #if CHIP_TYPE == CHIP_TYPE_TEMPLATE//Replace this with the chip you are porting
 
-#include "Port.h"
+#include "../Port.h"
 
 void InitCAN(int deviceGroup, int deviceAddress)
 {


### PR DESCRIPTION
PID targets are integers representing thousandths of a degree. The
software code has been assuming that these can be negative, but the CAN
library has been decoding them as unsigned ints.

In principle, we could do it using unsigned ints (by ensuring that we
always zero the encoders when all of the motors are at the proper joint
limit) but allowing negative values allows us more flexibility and is
less bug-prone.

Unrelated: Fix header file location for PortTemplate.c. In the software
repo we sometimes actually compile this file for testing purposes.