### PR TITLE
Added methods for assembling and disassembling pot init packets

### DIFF
--- a/CANMotorUnit.c
+++ b/CANMotorUnit.c
@@ -177,6 +177,46 @@ uint32_t GetMaxJointRevolutionsFromPacket(CANPacket *packet)
     return DecodeBytesToIntMSBFirst(packet->data, 1, 4);
 }
 
+void AssemblePotHiSetPacket(CANPacket *packetToAssemble,
+    uint8_t targetDeviceGroup,
+    uint8_t targetDeviceSerial,
+    uint16_t adcHi,
+    int32_t mdegHi)
+{
+    packetToAssemble->id = ConstructCANID(PRIO_MOTOR_UNIT_POT_INIT, targetDeviceGroup, targetDeviceSerial);
+    packetToAssemble->dlc = DLC_MOTOR_UNIT_POT_INIT;
+
+    int idx = WritePacketIDOnly(packetToAssemble->data, ID_MOTOR_UNIT_POT_INIT_HI);
+    PackShortIntoDataMSBFirst(packetToAssemble->data, adcHi, idx);
+    idx += 2;
+    PackIntIntoDataMSBFirst(packetToAssemble->data, mdegHi, idx);
+}
+
+void AssemblePotLoSetPacket(CANPacket *packetToAssemble,
+    uint8_t targetDeviceGroup,
+    uint8_t targetDeviceSerial,
+    uint16_t adcLo,
+    int32_t mdegLo)
+{
+    packetToAssemble->id = ConstructCANID(PRIO_MOTOR_UNIT_POT_INIT, targetDeviceGroup, targetDeviceSerial);
+    packetToAssemble->dlc = DLC_MOTOR_UNIT_POT_INIT;
+
+    int idx = WritePacketIDOnly(packetToAssemble->data, ID_MOTOR_UNIT_POT_INIT_LO);
+    PackShortIntoDataMSBFirst(packetToAssemble->data, adcLo, idx);
+    idx += 2;
+    PackIntIntoDataMSBFirst(packetToAssemble->data, mdegLo, idx);
+}
+
+uint16_t GetPotADCFromPacket(const CANPacket *packet)
+{
+    return DecodeBytesToIntMSBFirst(packet->data, 1, 2);
+}
+
+int32_t GetPotmDegFromPacket(const CANPacket *packet)
+{
+    return DecodeBytesToIntMSBFirst(packet->data, 3, 7);
+}
+
 void AssembleEncoderInitializePacket(CANPacket *packetToAssemble,
     uint8_t targetDeviceGroup,
     uint8_t targetDeviceSerial,

--- a/CANMotorUnit.c
+++ b/CANMotorUnit.c
@@ -209,7 +209,7 @@ void AssemblePotLoSetPacket(CANPacket *packetToAssemble,
 
 uint16_t GetPotADCFromPacket(const CANPacket *packet)
 {
-    return DecodeBytesToIntMSBFirst(packet->data, 1, 2);
+    return DecodeBytesToIntMSBFirst(packet->data, 1, 3);
 }
 
 int32_t GetPotmDegFromPacket(const CANPacket *packet)

--- a/CANMotorUnit.h
+++ b/CANMotorUnit.h
@@ -86,17 +86,62 @@ uint32_t GetMaxJointRevolutionsFromPacket(CANPacket *packet);
 
 
 // Potentiometer configuration packets
+/**
+ * @brief Assemble a packet to set the high point of the potentiometer.
+ *
+ * This, along with AssemblePotLoSetPacket() are required to initialize the potentiometer.
+ * Behavior is undefined if only one packet is sent and not the other.
+ *
+ * @param packetToAssemble The packet to write the data into.
+ * @param targetDeviceGroup The group of the target device.
+ * @param targetDeviceSerial Ther serial code of the target device.
+ * @param adcHi The raw ADC value of the pot at the max.
+ * @param mdegHi The joint pos in millideg at the max.
+ *
+ * @see https://github.com/huskyroboticsteam/HindsightCAN/wiki/Motor-Unit-Packets
+ */
 void AssemblePotHiSetPacket(CANPacket *packetToAssemble,
     uint8_t targetDeviceGroup,
     uint8_t targetDeviceSerial,
     uint16_t adcHi,
     int32_t mdegHi);
+
+/**
+ * @brief Assemble a packet to set the low point of the potentiometer.
+ *
+ * This, along with AssemblePotHiSetPacket() are required to initialize the potentiometer.
+ * Behavior is undefined if only one packet is sent and not the other.
+ *
+ * @param packetToAssemble The packet to write the data into.
+ * @param targetDeviceGroup The group of the target device.
+ * @param targetDeviceSerial Ther serial code of the target device.
+ * @param adcHi The raw ADC value of the pot at the low.
+ * @param mdegHi The joint pos in millideg at the low.
+ *
+ * @see https://github.com/huskyroboticsteam/HindsightCAN/wiki/Motor-Unit-Packets
+ */
 void AssemblePotLoSetPacket(CANPacket *packetToAssemble,
     uint8_t targetDeviceGroup,
     uint8_t targetDeviceSerial,
     uint16_t adcLo,
     int32_t mdegLo);
+
+/**
+ * @brief Get the raw ADC value from a pot initialization packet.
+ *
+ * @param packet The packet, produced by either AssemblePotHiSetPacket()
+ *               or AssemblePotLoSetPacket(), to read from.
+ * @return uint16_t The raw ADC value.
+ */
 uint16_t GetPotInitADCFromPacket(const CANPacket *packet);
+
+/**
+ * @brief Get the joint position from a pot initialization packet.
+ *
+ * @param packet The packet, produced by either AssemblePotHiSetPacket()
+ *               or AssemblePotLoSetPacket(), to read from.
+ * @return int32_t The joint position in millidegrees.
+ */
 int32_t GetPotInitmDegFromPacket(const CANPacket *packet);
 
 //Initialize Encoder Settings

--- a/CANMotorUnit.h
+++ b/CANMotorUnit.h
@@ -84,6 +84,21 @@ void AssembleMaxJointRevolutionPacket(CANPacket *packetToAssemble,
     uint32_t revolutions);
 uint32_t GetMaxJointRevolutionsFromPacket(CANPacket *packet);
 
+
+// Potentiometer configuration packets
+void AssemblePotHiSetPacket(CANPacket *packetToAssemble,
+    uint8_t targetDeviceGroup,
+    uint8_t targetDeviceSerial,
+    uint16_t adcHi,
+    int32_t mdegHi);
+void AssemblePotLoSetPacket(CANPacket *packetToAssemble,
+    uint8_t targetDeviceGroup,
+    uint8_t targetDeviceSerial,
+    uint16_t adcLo,
+    int32_t mdegLo);
+uint16_t GetPotInitADCFromPacket(const CANPacket *packet);
+int32_t GetPotInitmDegFromPacket(const CANPacket *packet);
+
 //Initialize Encoder Settings
 void AssembleEncoderInitializePacket(CANPacket *packetToAssemble,
     uint8_t targetDeviceGroup,
@@ -114,6 +129,8 @@ uint16_t GetMaxPIDPWMFromPacket(CANPacket *packet);
 #define ID_MOTOR_UNIT_MAX_JNT_REV_SET   (uint8_t) 0x0B
 #define ID_MOTOR_UNIT_ENC_INIT          (uint8_t) 0x0C
 #define ID_MOTOR_UNIT_MAX_PID_PWM       (uint8_t) 0x0D
+#define ID_MOTOR_UNIT_POT_INIT_LO       (uint8_t) 0x0F
+#define ID_MOTOR_UNIT_POT_INIT_HI       (uint8_t) 0x10
 
 // Packet DLCs
 #define DLC_MOTOR_UNIT_MODE_SEL             (uint8_t) 0x02
@@ -128,6 +145,7 @@ uint16_t GetMaxPIDPWMFromPacket(CANPacket *packet);
 #define DLC_MOTOR_UNIT_MAX_JNT_REV_SET      (uint8_t) 0x02
 #define DLC_MOTOR_UNIT_ENC_INIT             (uint8_t) 0x02
 #define DLC_MOTOR_UNIT_MAX_PID_PWM          (uint8_t) 0x03
+#define DLC_MOTOR_UNIT_POT_INIT             (uint8_t) 0x06
 
 //Packet priorities 
 #define PRIO_MOTOR_UNIT_MODE_SEL            PACKET_PRIORITY_NORMAL
@@ -142,6 +160,7 @@ uint16_t GetMaxPIDPWMFromPacket(CANPacket *packet);
 #define PRIO_MOTOR_UNIT_MAX_JNT_REV_SET     PACKET_PRIORITY_NORMAL
 #define PRIO_MOTOR_UNIT_ENC_INIT            PACKET_PRIORITY_NORMAL
 #define PRIO_MOTOR_UNIT_MAX_PID_PWM         PACKET_PRIORITY_NORMAL
+#define PRIO_MOTOR_UNIT_POT_INIT            PACKET_PRIORITY_NORMAL
 
 // Motor Unit Mode IDs
 #define MOTOR_UNIT_MODE_PWM             (uint8_t) 0x00

--- a/CANPacket.c
+++ b/CANPacket.c
@@ -209,7 +209,7 @@ void PackShortIntoDataMSBFirst(uint8_t *data, int16_t dataToPack, int startIndex
 	data[startIndex + 1] = (dataToPack & 0x00FF);
 }
 
-int32_t DecodeBytesToIntMSBFirst(uint8_t *data, int startIndex, int endIndex)
+int32_t DecodeBytesToIntMSBFirst(const uint8_t *data, int startIndex, int endIndex)
 {
     int length = 4;
     int32_t decodedData = 0; 

--- a/CANPacket.h
+++ b/CANPacket.h
@@ -43,6 +43,16 @@ int PacketIsOfID(CANPacket *packet, uint8_t expectedID);
 
 void PackIntIntoDataMSBFirst(uint8_t *data, int32_t dataToPack, int startIndex);
 void PackShortIntoDataMSBFirst(uint8_t *data, int16_t dataToPack, int startIndex);
+/**
+ * @brief Read at most 4 bytes into a signed int.
+ *
+ * @param data The array of bytes to read from, storing the bytes in big-endian order.
+ * @param startIndex The index of the MSB.
+ * @param endIndex The index after the LSB.
+ * @return int32_t The decoded integer.
+ *
+ * @warning Be careful using this for unsigned data, as it could overflow.
+ */
 int32_t DecodeBytesToIntMSBFirst(const uint8_t *data, int startIndex, int endIndex);
 
 // Device group nibbles

--- a/CANPacket.h
+++ b/CANPacket.h
@@ -43,7 +43,7 @@ int PacketIsOfID(CANPacket *packet, uint8_t expectedID);
 
 void PackIntIntoDataMSBFirst(uint8_t *data, int32_t dataToPack, int startIndex);
 void PackShortIntoDataMSBFirst(uint8_t *data, int16_t dataToPack, int startIndex);
-int32_t DecodeBytesToIntMSBFirst(uint8_t *data, int startIndex, int endIndex);
+int32_t DecodeBytesToIntMSBFirst(const uint8_t *data, int startIndex, int endIndex);
 
 // Device group nibbles
 #define DEVICE_GROUP_BROADCAST          (uint8_t) 0x00

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ include(CMakePackageConfigHelpers)
 #   backwards-compatible changes or bug fixes.
 project(HindsightCAN
   LANGUAGES C
-  VERSION 1.0.3) # <-- Change when you make commits to master; see above
+  VERSION 1.0.4) # <-- Change when you make commits to master; see above
 
 # The list of header files for the CAN library
 set(CAN_HEADERS


### PR DESCRIPTION
This PR adds the required methods for assembling packets for pot initialization, as well as getting the relevant fields from those packets.

I'll add these packets to the wiki now.