### PR TITLE
Adding packets for Science Stepper motor control. 

### DIFF
--- a/CANMotorUnit.h
+++ b/CANMotorUnit.h
@@ -167,7 +167,7 @@ uint16_t GetMaxPIDPWMFromPacket(CANPacket *packet);
  * @param packetToAssemble The packet to write the data into.
  * @param targetDeviceGroup The group of the target device.
  * @param targetDeviceSerial The serial code of the target device.
- * @param serverNum The servo number
+ * @param servoNum The servo number
  * @param angle The angle degree in millidegrees
  *
  * @see https://github.com/huskyroboticsteam/HindsightCAN/wiki/Motor-Unit-Packets
@@ -175,7 +175,7 @@ uint16_t GetMaxPIDPWMFromPacket(CANPacket *packet);
 void AssemblePCAServoPacket(CANPacket *packetToAssemble,
     uint8_t targetDeviceGroup,
     uint8_t targetDeviceSerial,
-    uint8_t serverNum,
+    uint8_t servoNum,
     int32_t angle);
 
 /**

--- a/CANScience.c
+++ b/CANScience.c
@@ -44,14 +44,17 @@ void AssembleScienceStepperTurnAnglePacket(CANPacket *packetToAssemble,
 	uint8_t targetDeviceGroup,
 	uint8_t targetDeviceSerial,
 	uint8_t stepperID,
-	int16_t degrees)
+	int16_t degrees,
+	uint8_t speed)
 {
 	packetToAssemble->id = ConstructCANID(PACKET_PRIORITY_NORMAL, targetDeviceGroup, targetDeviceSerial);
-	packetToAssemble->dlc = 4;
+	packetToAssemble->dlc = 5;
 	int nextByte = WritePacketIDOnly(packetToAssemble->data, ID_SCIENCE_STEPPER_TURN_ANGLE);
 	packetToAssemble->data[nextByte] = stepperID;
 	nextByte++;
 	PackShortIntoDataMSBFirst(packetToAssemble->data, degrees, nextByte);
+	nextByte += sizeof(degrees);
+	packetToAssemble->data[nextByte] = speed;
 	
 }
 
@@ -59,14 +62,17 @@ void AssembleScienceStepperTurnStepsPacket(CANPacket *packetToAssemble,
 	uint8_t targetDeviceGroup,
 	uint8_t targetDeviceSerial,
 	uint8_t stepperID,
-	int16_t steps)
+	int16_t steps, 
+	uint8_t speed)
 {
 	packetToAssemble->id = ConstructCANID(PACKET_PRIORITY_NORMAL, targetDeviceGroup, targetDeviceSerial);
-	packetToAssemble->dlc = 4;
+	packetToAssemble->dlc = 5;
 	int nextByte = WritePacketIDOnly(packetToAssemble->data, ID_SCIENCE_STEPPER_TURN_STEPS);
 	packetToAssemble->data[nextByte] = stepperID;
 	nextByte++;
 	PackShortIntoDataMSBFirst(packetToAssemble->data, steps, nextByte);
+	nextByte += sizeof(steps);
+	packetToAssemble->data[nextByte] = speed;
 }
 
 int8_t GetScienceContServoPowerFromPacket(const CANPacket *packet) {
@@ -85,6 +91,10 @@ int16_t GetStepperAngleFromPacket(const CANPacket *packet) {
 int16_t GetStepperStepsFromPacket(const CANPacket *packet) {
 	return (int16_t)DecodeBytesToIntMSBFirst(packet->data,2,3);
 	
+}
+
+uint8_t GetStepperSpeedFromPacket(const CANPacket *packet) {
+	return packet->data[4];
 }
 
 uint8_t GetScienceLazySusanPosFromPacket(const CANPacket *packet) {

--- a/CANScience.c
+++ b/CANScience.c
@@ -40,12 +40,51 @@ void AssembleScienceContServoPowerSetPacket(CANPacket *packetToAssemble,
 	packetToAssemble->data[2] = power;
 }
 
+void AssembleScienceStepperTurnAnglePacket(CANPacket *packetToAssemble,
+	uint8_t targetDeviceGroup,
+	uint8_t targetDeviceSerial,
+	uint8_t stepperID,
+	int16_t degrees)
+{
+	packetToAssemble->id = ConstructCANID(PACKET_PRIORITY_NORMAL, targetDeviceGroup, targetDeviceSerial);
+	packetToAssemble->dlc = 4;
+	int nextByte = WritePacketIDOnly(packetToAssemble->data, ID_SCIENCE_STEPPER_TURN_ANGLE);
+	packetToAssemble->data[nextByte] = stepperID;
+	nextByte++;
+	PackShortIntoDataMSBFirst(packetToAssemble->data, degrees, nextByte);
+	
+}
+
+void AssembleScienceStepperTurnStepsPacket(CANPacket *packetToAssemble,
+	uint8_t targetDeviceGroup,
+	uint8_t targetDeviceSerial,
+	uint8_t stepperID,
+	int16_t steps)
+{
+	packetToAssemble->id = ConstructCANID(PACKET_PRIORITY_NORMAL, targetDeviceGroup, targetDeviceSerial);
+	packetToAssemble->dlc = 4;
+	int nextByte = WritePacketIDOnly(packetToAssemble->data, ID_SCIENCE_STEPPER_TURN_STEPS);
+	packetToAssemble->data[nextByte] = stepperID;
+	nextByte++;
+	PackShortIntoDataMSBFirst(packetToAssemble->data, steps, nextByte);
+}
+
 int8_t GetScienceContServoPowerFromPacket(const CANPacket *packet) {
 	return packet->data[2];
 }
 
 uint8_t GetScienceServoAngleFromPacket(const CANPacket *packet){
 	return packet->data[2];
+}
+
+int16_t GetStepperAngleFromPacket(const CANPacket *packet) {
+	return (int16_t)DecodeBytesToIntMSBFirst(packet->data,2,3);
+	
+}
+
+int16_t GetStepperStepsFromPacket(const CANPacket *packet) {
+	return (int16_t)DecodeBytesToIntMSBFirst(packet->data,2,3);
+	
 }
 
 uint8_t GetScienceLazySusanPosFromPacket(const CANPacket *packet) {
@@ -55,5 +94,10 @@ uint8_t GetScienceLazySusanPosFromPacket(const CANPacket *packet) {
 uint8_t GetScienceServoIDFromPacket(const CANPacket *packet){
 	return packet->data[1];
 }
+
+uint8_t GetScienceStepperIDFromPacket(const CANPacket *packet){
+	return packet->data[1];
+}
+
 
 

--- a/CANScience.h
+++ b/CANScience.h
@@ -26,6 +26,15 @@
    Packet ID for the continuous rotation servo power set packet.
  */
 #define ID_SCIENCE_CONT_SERVO_POWER_SET ((uint8_t) 0x0E)
+/**
+   Packet ID for the turn stepper motor by angle packet.
+ */
+#define ID_SCIENCE_STEPPER_TURN_ANGLE   ((uint8_t) 0x0B)
+/**
+   Packet ID for the turn stepper motor by a given amount of steps packet.
+ */
+#define ID_SCIENCE_STEPPER_TURN_STEPS   ((uint8_t) 0x0A)
+
 
 #include "CANPacket.h"
 
@@ -94,6 +103,43 @@ void AssembleScienceContServoPowerSetPacket(CANPacket *packetToAssemble,
 											int8_t power);
 
 /**
+ * @brief Assemble a packet to turn one of the stepper motors a certain number of degrees.
+ * 
+ * @param packetToAssemble The packet to write the data into.
+ * @param targetDeviceGroup The group of the target device.
+ * @param targetDeviceSerial The serial code of the target device.
+ * @param stepperID ID number of the stepper motor to turn.
+ * @param degrees degrees to turn stepper. Positive is clockwise.
+ *
+ * @warning Angle should be in degrees, not milidegrees.
+ *
+ * @see https://github.com/huskyroboticsteam/HindsightCAN/wiki/Science-Board-Packets
+ */
+void AssembleScienceStepperTurnAnglePacket(CANPacket *packetToAssemble,
+  uint8_t targetDeviceGroup,
+  uint8_t targetDeviceSerial,
+  uint8_t stepperID,
+  int16_t degrees);
+
+  /**
+ * @brief Assemble a packet to turn one of the stepper motors a certain number of degrees.
+ * 
+ * @param packetToAssemble The packet to write the data into.
+ * @param targetDeviceGroup The group of the target device.
+ * @param targetDeviceSerial The serial code of the target device.
+ * @param stepperID ID number of the stepper motor to turn.
+ * @param steps number of steps to turn stepper. Positive is clockwise.
+ *
+ *
+ * @see https://github.com/huskyroboticsteam/HindsightCAN/wiki/Science-Board-Packets
+ */
+void AssembleScienceStepperTurnStepsPacket(CANPacket *packetToAssemble,
+  uint8_t targetDeviceGroup,
+  uint8_t targetDeviceSerial,
+  uint8_t stepperID,
+  int16_t steps);
+
+/**
  *  @brief Gets the servo ID from a science station servo packet.
  *  @param A CANPacket, that is one of the two science station servo-related packets.
  *  @return The servo ID for the packet.
@@ -104,6 +150,17 @@ void AssembleScienceContServoPowerSetPacket(CANPacket *packetToAssemble,
 uint8_t GetScienceServoIDFromPacket(const CANPacket *packet);
 
 /**
+ *  @brief Gets the stepper ID from a science station servo packet.
+ *  @param A CANPacket, that is one of the two science station stepper-related packets.
+ *  @return The stepper ID for the packet.
+ *
+ *  @warning This function is intended to be used only on stepper-related packets; return value
+ *  is undefined if packet is not a stepper packet.
+ */
+uint8_t GetScienceStepperIDFromPacket(const CANPacket *packet);
+
+
+/**
  *  @brief Gets the servo angle from a science station servo set packet.
  *  @param A science station servo set packet, as a CANPacket
  *  @return The servo angle in this packet.
@@ -112,6 +169,29 @@ uint8_t GetScienceServoIDFromPacket(const CANPacket *packet);
  *  value is undefined otherwise.
  */
 uint8_t GetScienceServoAngleFromPacket(const CANPacket *packet);
+
+
+/**
+ *  @brief Gets the stepper angle from a science station stepper turn angle set packet.
+ *  @param A science station stepper turn angle packet, as a CANPacket
+ *  @return The stepper angle in this packet.
+ *
+ *  @warning This function is intended to be used only on stepper motor turn angle packets; return
+ *  value is undefined otherwise.
+ */
+int16_t GetStepperAngleFromPacket(const CANPacket *packet);
+
+
+/**
+ *  @brief Gets the stepper angle from a science station stepper turn steps packet.
+ *  @param A science station stepper turn steps packet, as a CANPacket
+ *  @return The stepper steps in this packet.
+ *
+ *  @warning This function is intended to be used only on stepper motor turn  packets; return
+ *  value is undefined otherwise.
+ */
+int16_t GetStepperStepsFromPacket(const CANPacket *packet);
+
 
 /**
  *  @brief Gets the Lazy Susan position from a science station Lazy Susan position set packet.

--- a/CANScience.h
+++ b/CANScience.h
@@ -110,6 +110,7 @@ void AssembleScienceContServoPowerSetPacket(CANPacket *packetToAssemble,
  * @param targetDeviceSerial The serial code of the target device.
  * @param stepperID ID number of the stepper motor to turn.
  * @param degrees degrees to turn stepper. Positive is clockwise.
+ * @param speed speed to turn stepper motor.
  *
  * @warning Angle should be in degrees, not milidegrees.
  *
@@ -119,7 +120,8 @@ void AssembleScienceStepperTurnAnglePacket(CANPacket *packetToAssemble,
   uint8_t targetDeviceGroup,
   uint8_t targetDeviceSerial,
   uint8_t stepperID,
-  int16_t degrees);
+  int16_t degrees,
+  uint8_t speed);
 
   /**
  * @brief Assemble a packet to turn one of the stepper motors a certain number of degrees.
@@ -129,6 +131,7 @@ void AssembleScienceStepperTurnAnglePacket(CANPacket *packetToAssemble,
  * @param targetDeviceSerial The serial code of the target device.
  * @param stepperID ID number of the stepper motor to turn.
  * @param steps number of steps to turn stepper. Positive is clockwise.
+ * @param speed speed to turn stepper motor.
  *
  *
  * @see https://github.com/huskyroboticsteam/HindsightCAN/wiki/Science-Board-Packets
@@ -137,7 +140,8 @@ void AssembleScienceStepperTurnStepsPacket(CANPacket *packetToAssemble,
   uint8_t targetDeviceGroup,
   uint8_t targetDeviceSerial,
   uint8_t stepperID,
-  int16_t steps);
+  int16_t steps,
+  uint8_t speed);
 
 /**
  *  @brief Gets the servo ID from a science station servo packet.
@@ -187,10 +191,21 @@ int16_t GetStepperAngleFromPacket(const CANPacket *packet);
  *  @param A science station stepper turn steps packet, as a CANPacket
  *  @return The stepper steps in this packet.
  *
- *  @warning This function is intended to be used only on stepper motor turn  packets; return
+ *  @warning This function is intended to be used only on stepper motor turn steps packets; return
  *  value is undefined otherwise.
  */
 int16_t GetStepperStepsFromPacket(const CANPacket *packet);
+
+
+/**
+ *  @brief Gets the stepper speed from a science station stepper turn steps/angles packet.
+ *  @param A science station stepper turn steps packet, as a CANPacket
+ *  @return The stepper speed in this packet.
+ *
+ *  @warning This function is intended to be used only on stepper motor turn angle or steps packets; return
+ *  value is undefined otherwise.
+ */
+uint8_t GetStepperSpeedFromPacket(const CANPacket *packet);
 
 
 /**


### PR DESCRIPTION
Send packets to turn science stepper motors by a certain angle or number of steps. 