### PR TITLE
added functions and packet for science sensors digital peripherals

### DIFF
--- a/CANCommon.c
+++ b/CANCommon.c
@@ -258,3 +258,26 @@ void AssembleRGBColorPacket(CANPacket *packetToAssemble,
     packetToAssemble->data[nextByte + 2] = B;
     packetToAssemble->data[nextByte + 3] = addrLED;   
 }
+
+void AssembleDigitalSetPacket(CANPacket *packetToAssemble,
+    uint8_t targetGroup,
+    uint8_t targetSerial,
+    uint8_t pinAddr,
+    uint8_t setValue)
+{
+    packetToAssemble->id = ConstructCANID(PACKET_PRIORITY_NORMAL, targetGroup, targetSerial);
+    packetToAssemble->dlc = DLC_DIGITAL_SET;
+    int nextByte = WritePacketIDOnly(packetToAssemble->data, ID_DIGITAL_SET);
+    packetToAssemble->data[nextByte] = pinAddr;
+    packetToAssemble->data[nextByte + 1] = setValue;   
+}
+
+uint8_t GetDigitalSetAddrFromPacket(CANPacket *packet)
+{
+    return packet->data[1];
+}
+
+uint8_t GetDigitalSetValueFromPacket(CANPacket *packet)
+{
+    return packet->data[2];
+}

--- a/CANCommon.h
+++ b/CANCommon.h
@@ -75,6 +75,34 @@ void AssembleRGBColorPacket(CANPacket *packetToAssemble,
     uint8_t G,
     uint8_t B);
 
+/*
+ * Creates a packet containing a digital peripheral address and
+ * value to set the peripheral to. Puts together address to send
+ * the packet to.
+ * @param CANPacket * packetToAssemble - pointer to where to put the packet
+ * @param uint8_t targetGroup - device group to send packet to
+ * @param uint8_t targetSerial - serial number to send the packet to
+ * @param uint8_t pinAddr - address of peripheral to set
+ * @param uint8_t setValue - value to set the peripheral to
+ */
+void AssembleDigitalSetPacket(CANPacket *packetToAssemble,
+    uint8_t targetGroup,
+    uint8_t targetSerial,
+    uint8_t pinAddr,
+    uint8_t setValue);
+  
+/*
+ * Gets the digital peripheral address to set from a given CAN packet.
+ * @param CANPacket * packet - received packet to extract address from
+ */
+uint8_t GetDigitalSetAddrFromPacket(CANPacket *packet);
+
+/*
+ * Gets the desired digital peripheral value from a given CAN packet.
+ * @param CANPacket * packet - received packet to extract digital value from
+ */
+uint8_t GetDigitalSetValueFromPacket(CANPacket *packet);    
+
 // Common Mode Packet IDs
 #define ID_ESTOP                        (uint8_t) 0xF0
 #define ID_HEARTBEAT                    (uint8_t) 0xF1
@@ -86,6 +114,7 @@ void AssembleRGBColorPacket(CANPacket *packetToAssemble,
 #define ID_LED_COLOR                    (uint8_t) 0xF7
 #define ID_CHIP_TYPE_PULL               (uint8_t) 0xF8
 #define ID_CHIP_TYPE_REP                (uint8_t) 0xF9
+#define ID_DIGITAL_SET                  (uint8_t) 0xFA
 
 // DLC Common Mode Packets 
 #define DLC_ESTOP                        (uint8_t) 0x04
@@ -98,6 +127,7 @@ void AssembleRGBColorPacket(CANPacket *packetToAssemble,
 #define DLC_LED_COLOR                    (uint8_t) 0x06
 #define DLC_CHIP_TYPE_PULL               (uint8_t) 0x04
 #define DLC_CHIP_TYPE_REP                (uint8_t) 0x04
+#define DLC_DIGITAL_SET                  (uint8_t) 0x03
 
 //Packet priorities
 #define PRIO_CHIP_TYPE_REP               PACKET_PRIORITY_NORMAL

--- a/CANScience.h
+++ b/CANScience.h
@@ -27,6 +27,21 @@
  */
 #define ID_SCIENCE_CONT_SERVO_POWER_SET ((uint8_t) 0x0E)
 
+/**
+  Sensor board address for the laser control.
+ */
+#define SCIENCE_SENSOR_LASER ((uint8_t) 0x01)
+
+/**
+  Sensor board address for the water pump 1 control.
+ */
+#define SCIENCE_SENSOR_WATER_PUMP_1 ((uint8_t) 0x02)
+
+/**
+  Sensor board address for the water pump 2 control.
+ */
+#define SCIENCE_SENSOR_WATER_PUMP_2 ((uint8_t) 0x03)
+
 #include "CANPacket.h"
 
 /**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if(NOT IS_SUBPROJECT)
   #   backwards-compatible changes or bug fixes.
   project(HindsightCAN
     LANGUAGES C
-    VERSION 1.6.1) # <-- Change when you make commits to master; see above
+    VERSION 1.6.2) # <-- Change when you make commits to master; see above
 endif()
 
 # The list of header files for the CAN library


### PR DESCRIPTION
Can set science sensor digital output through a CAN packet with a peripheral address and a set value.